### PR TITLE
Add test cases and fix UTM zone parsing in EnmapProductReader

### DIFF
--- a/opttbx-enmap-reader/src/main/java/eu/esa/opt/dataio/enmap/EnmapProductReader.java
+++ b/opttbx-enmap-reader/src/main/java/eu/esa/opt/dataio/enmap/EnmapProductReader.java
@@ -95,7 +95,7 @@ class EnmapProductReader extends AbstractProductReader {
     static String getEPSGCode(String projection) throws Exception {
         int code;
         if (projection.startsWith("UTM")) {
-            int utmZone = Integer.parseInt(projection.substring(8, 10));
+            int utmZone = Integer.parseInt(projection.substring(8, projection.lastIndexOf("_")));
             if (projection.endsWith("North")) {
                 code = 32600 + utmZone;
             } else {

--- a/opttbx-enmap-reader/src/test/java/eu/esa/opt/dataio/enmap/EnmapProductReaderTest.java
+++ b/opttbx-enmap-reader/src/test/java/eu/esa/opt/dataio/enmap/EnmapProductReaderTest.java
@@ -9,6 +9,8 @@ public class EnmapProductReaderTest {
 
     @Test
     public void testGetEPSGCode() throws Exception {
+        assertEquals("EPSG:32608", EnmapProductReader.getEPSGCode("UTM_Zone8_North"));
+        assertEquals("EPSG:32708", EnmapProductReader.getEPSGCode("UTM_Zone08_South"));
         assertEquals("EPSG:32632", EnmapProductReader.getEPSGCode("UTM_Zone32_North"));
         assertEquals("EPSG:32714", EnmapProductReader.getEPSGCode("UTM_Zone14_South"));
         assertEquals("EPSG:3035", EnmapProductReader.getEPSGCode("LAEA-ETRS89"));


### PR DESCRIPTION
New test cases were added to EnmapProductReaderTest for UTM Zone8 North and South. The UTM zone parsing logic in EnmapProductReader was fixed to properly extract the zone number from the projection string.