### PR TITLE
fix: ColorModel is incompatible with the image SampleModel

### DIFF
--- a/opttbx-s2msi-reader/src/main/java/eu/esa/opt/dataio/s2/l1b/Sentinel2L1BProductReader.java
+++ b/opttbx-s2msi-reader/src/main/java/eu/esa/opt/dataio/s2/l1b/Sentinel2L1BProductReader.java
@@ -76,9 +76,7 @@ import java.util.logging.Level;
 
 import static eu.esa.opt.dataio.s2.S2Metadata.ProductCharacteristics;
 import static eu.esa.opt.dataio.s2.S2Metadata.Tile;
-import static eu.esa.opt.dataio.s2.l1b.CoordinateUtils.convertDoublesToFloats;
-import static eu.esa.opt.dataio.s2.l1b.CoordinateUtils.getLatitudes;
-import static eu.esa.opt.dataio.s2.l1b.CoordinateUtils.getLongitudes;
+import static eu.esa.opt.dataio.s2.l1b.CoordinateUtils.*;
 import static eu.esa.opt.dataio.s2.l1b.metadata.L1bMetadataProc.makeTileInformation;
 import static org.esa.snap.core.util.DateTimeUtils.parseDate;
 
@@ -460,7 +458,7 @@ public class Sentinel2L1BProductReader extends Sentinel2ProductReader {
 
         TileIndexMultiLevelSource multiLevelSource = new TileIndexMultiLevelSource(resolutionCount, mosaicMatrix, bandBounds, preferredTileSize,
                                                                                    imageToModelTransform, mosaicOpSourceThreshold, mosaicOpBackgroundValue);
-        ImageLayout imageLayout = ImageUtils.buildImageLayout(dataBufferType, bandBounds.width, bandBounds.height, 0, preferredTileSize);
+        ImageLayout imageLayout = ImageUtils.buildImageLayout(multiLevelSource.getImage(0), 0, preferredTileSize);
         band.setSourceImage(new DefaultMultiLevelImage(multiLevelSource, imageLayout));
 
         return band;

--- a/opttbx-s2msi-reader/src/main/java/eu/esa/opt/dataio/s2/ortho/Sentinel2OrthoProductReader.java
+++ b/opttbx-s2msi-reader/src/main/java/eu/esa/opt/dataio/s2/ortho/Sentinel2OrthoProductReader.java
@@ -1253,8 +1253,7 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
             TileIndexMultiLevelSource tileIndex = new TileIndexMultiLevelSource(resolutionCount, mosaicMatrix,
                                                                                 bandBounds, preferredTileSize, imageToModelTransform, mosaicOpSourceThreshold,
                                                                                 mosaicOpBackgroundValue);
-            ImageLayout imageLayout = ImageUtils.buildImageLayout(dataBufferType, bandBounds.width, bandBounds.height,
-                                                                  0, preferredTileSize);
+            ImageLayout imageLayout = ImageUtils.buildImageLayout(tileIndex.getImage(0),0, preferredTileSize);
             band.setSourceImage(new DefaultMultiLevelImage(tileIndex, imageLayout));
 
             product.addBand(band);


### PR DESCRIPTION
This PR needs the PR for snap-engine with the same name.

In Sentinel2L1BProductReader and Sentinel2OrthoProductReader ImageLayouts were created which didn’t match the image. In ImageUtils arbitrary models are created. Now, I’ve added a method to ImageUtils, which considers the SampleModel and ColorModel of an existing image.

Shall fix the exception:
java.lang.IllegalArgumentException: The specified ColorModel is incompatible with the image SampleModel.
at javax.media.jai.PlanarImage.setImageLayout(Unknown Source)
at javax.media.jai.PlanarImage.<init>(Unknown Source)
at javax.media.jai.OpImage.<init>(Unknown Source)
at javax.media.jai.SourcelessOpImage.<init>(Unknown Source)
at com.bc.ceres.glevel.MultiLevelImage.<init>(MultiLevelImage.java:42)
at com.bc.ceres.glevel.support.DefaultMultiLevelImage.<init>(DefaultMultiLevelImage.java:54)
