### PR TITLE
Remove unnecessary public package

### DIFF
--- a/opttbx-s2msi-reader/pom.xml
+++ b/opttbx-s2msi-reader/pom.xml
@@ -134,7 +134,6 @@
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
                     <publicPackages>
-                        <publicPackage>org.apache.commons.*</publicPackage>
                         <publicPackage>eu.esa.opt.dataio.s2.*</publicPackage>
                     </publicPackages>
                 </configuration>


### PR DESCRIPTION
The public package for 'org.apache.commons.*' was removed. It caused #88