### PR TITLE
S2reader commons-io dependency issue

### DIFF
--- a/opttbx-s2msi-reader/pom.xml
+++ b/opttbx-s2msi-reader/pom.xml
@@ -49,10 +49,6 @@
             <artifactId>snap-ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-engine-utilities</artifactId>
         </dependency>


### PR DESCRIPTION
Moved commons-io dependency from opttbx-s2msi-reader to snap-core to centralize its usage. This ensures consistent versioning across modules and avoids redundancy.

see also: https://forum.step.esa.int/t/commons-io-dependency-issue-in-s2msi-reader/44516

This should resolve the issue when a module depends on s2msi-reader, snap-core and commons-io. In this case the module does not know where to load the classes from.  
`java.lang.ClassNotFoundException: Will not load class org.apache.commons.io.input.ReversedLinesFileReader arbitrarily from one of ModuleCL@4bc08f13[eu.esa.opt.opttbx.s2msi.reader] and ModuleCL@29091e7a[org.esa.snap.snap.core] starting from ModuleCL@e56c0cf[org.eomasters.eomtbx]`

There is a related pull request for the snap: https://github.com/senbox-org/snap-engine/pull/531