### PR TITLE
Update help map file with corrected URLs for Create_MODIS_L1X and AuxDataDirectory

### DIFF
--- a/opttbx-c2rcc/src/main/javahelp/eu/esa/opt/opttbx/c2rcc/docs/map.jhm
+++ b/opttbx-c2rcc/src/main/javahelp/eu/esa/opt/opttbx/c2rcc/docs/map.jhm
@@ -9,7 +9,7 @@
     <mapID target="c2rccAlgorithmSpec" url="c2rcc/C2RCCAlgorithmSpecification.html"/>
     <mapID target="c2rccProcessorDesc" url="c2rcc/C2RCCProcessorDescription.html"/>
     <mapID target="c2rccIOParameters" url="c2rcc/C2RCCIOParameters.html"/>
-    <mapID target="c2rccModisL1C" url="c2rcc/C2RCCIOParameters.html"/>
-    <mapID target="c2rccAuxDataDir" url="c2rcc/C2RCCIOParameters.html"/>
+    <mapID target="c2rccModisL1C" url="c2rcc/Create_MODIS_L1C.html"/>
+    <mapID target="c2rccAuxDataDir" url="c2rcc/AuxDataDirectory.html"/>
 
 </map>


### PR DESCRIPTION
Fixed incorrect URLs in the map.jhm file for "c2rccModisL1C" and "c2rccAuxDataDir" targets. This ensures the help system points to the correct documentation pages.