### PR TITLE
fix_TP_GeoCoding_for_S3 #2

### DIFF
--- a/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/Sentinel3DddbReader.java
+++ b/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/Sentinel3DddbReader.java
@@ -145,7 +145,7 @@ public class Sentinel3DddbReader extends AbstractProductReader implements Metada
     }
 
     // @todo 2 tb/tb add tests for this 2025-02-04
-    public static void extractSubset(RasterExtract rasterExtract, ProductData destBuffer, Array rawDataArray, double scaleFactor, double offset, boolean rawData) throws IOException {
+    public static void extractSubset(RasterExtract rasterExtract, ProductData destBuffer, Array rawDataArray, double scaleFactor, double offset, boolean logScaled, boolean rawData) throws IOException {
         final int[] sliceOffset = new int[]{rasterExtract.getYOffset(), rasterExtract.getXOffset()};
         //final int stepY = Math.max(rasterExtract.getStepY() - 1, 1);
         //final int stepX = Math.max(rasterExtract.getStepX()-1 , 1);
@@ -158,9 +158,14 @@ public class Sentinel3DddbReader extends AbstractProductReader implements Metada
 
         try {
             Array sliceData = rawDataArray.section(sliceOffset, sliceDimensions, stride).copy().reduce();
-            if (!rawData) {
+            if (!rawData && ReaderUtils.mustScale(scaleFactor, offset)) {
                 sliceData = ReaderUtils.scaleArray(sliceData, scaleFactor, offset);
             }
+
+            if (logScaled) {
+                ReaderUtils.invLogScaling(sliceData);
+            }
+
             assignResultData(destBuffer, sliceData);
         } catch (InvalidRangeException e) {
             throw new IOException(e);
@@ -378,8 +383,8 @@ public class Sentinel3DddbReader extends AbstractProductReader implements Metada
         final ProductData productDataLat = ProductData.createInstance(new double[bufferSize]);
 
         final RasterExtract rasterExtract = new RasterExtract(0, 0, width, height, 1, 1);
-        readData(rasterExtract, productDataLon, lonDescriptor, geoLocationNames.getTpLongitudeName(), true);
-        readData(rasterExtract, productDataLat, latDescriptor, geoLocationNames.getTpLatitudeName(), true);
+        readData(rasterExtract, productDataLon, lonDescriptor, geoLocationNames.getTpLongitudeName(), false);
+        readData(rasterExtract, productDataLat, latDescriptor, geoLocationNames.getTpLatitudeName(), false);
 
         final double resolutionInKm = sensorContext.getResolutionInKm(product.getProductType());
         final GeoRaster geoRaster = new GeoRaster((double[]) productDataLon.getElems(), (double[]) productDataLat.getElems(),
@@ -637,7 +642,8 @@ public class Sentinel3DddbReader extends AbstractProductReader implements Metada
 
         final double scalingFactor = getScalingFactor(netCDFVariable);
         double offset = getAddOffset(netCDFVariable);
-        extractSubset(rasterExtract, destBuffer, rawDataArray, scalingFactor, offset, rawData);
+        final boolean logScaled = isLogScaled(netCDFVariable);
+        extractSubset(rasterExtract, destBuffer, rawDataArray, scalingFactor, offset, logScaled, rawData);
     }
 
     private Variable getNetCDFVariable(VariableDescriptor descriptor, String name) throws IOException {

--- a/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/Sentinel3DddbReader.java
+++ b/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/Sentinel3DddbReader.java
@@ -158,14 +158,15 @@ public class Sentinel3DddbReader extends AbstractProductReader implements Metada
 
         try {
             Array sliceData = rawDataArray.section(sliceOffset, sliceDimensions, stride).copy().reduce();
-            if (!rawData && ReaderUtils.mustScale(scaleFactor, offset)) {
-                sliceData = ReaderUtils.scaleArray(sliceData, scaleFactor, offset);
-            }
+            if (!rawData) {
+                if (ReaderUtils.mustScale(scaleFactor, offset)) {
+                    sliceData = ReaderUtils.scaleArray(sliceData, scaleFactor, offset);
+                }
 
-            if (logScaled) {
-                ReaderUtils.invLogScaling(sliceData);
+                if (logScaled) {
+                    ReaderUtils.invLogScaling(sliceData);
+                }
             }
-
             assignResultData(destBuffer, sliceData);
         } catch (InvalidRangeException e) {
             throw new IOException(e);

--- a/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/olci/InstrumentBand.java
+++ b/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/olci/InstrumentBand.java
@@ -43,7 +43,7 @@ public class InstrumentBand extends BandUsingReaderDirectly {
 
         // Define subset to requested region
         final RasterExtract rasterExtract = new RasterExtract(offsetX, offsetY, width, height, 1, 1);
-        Sentinel3DddbReader.extractSubset(rasterExtract, rasterData, productData, getScalingFactor(), getScalingOffset(), true);
+        Sentinel3DddbReader.extractSubset(rasterExtract, rasterData, productData, getScalingFactor(), getScalingOffset(), isLog10Scaled(), true);
     }
 
     @Override

--- a/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/util/S3Util.java
+++ b/opttbx-sentinel3-reader/src/main/java/eu/esa/opt/dataio/s3/util/S3Util.java
@@ -1,7 +1,6 @@
 package eu.esa.opt.dataio.s3.util;
 
 import com.bc.ceres.core.VirtualDir;
-import eu.esa.opt.dataio.s3.olci.OlciContext;
 import org.esa.snap.core.dataio.geocoding.forward.PixelForward;
 import org.esa.snap.core.dataio.geocoding.forward.PixelInterpolatingForward;
 import org.esa.snap.core.dataio.geocoding.forward.TiePointBilinearForward;
@@ -123,6 +122,11 @@ public class S3Util {
             return S3Util.getAttributeValue(attribute).doubleValue();
         }
         return 0.0;
+    }
+
+    public static boolean isLogScaled(Variable variable) {
+        String description = variable.getDescription();
+        return description != null && description.startsWith("log10 scaled");
     }
 
     public static int getRasterDataType(Variable variable) {


### PR DESCRIPTION
This this comes a little late. You just merged the other PR.
I think, now I understand why the rawData parameter is needed for Sentinel3DddbReader#readData() and the follow up methods. It shall still be possible to load the rawData even if the data is scaled So I reintroduced it. but combined it with the condition [scaleFactor != 1.0 || offset != 0.0] to prevent unnecessary scaling for SLSTR tie-points. Also I consider log scaling.

To this PR belongs also one in the netcdf reader. https://github.com/senbox-org/snap-engine/pull/605